### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Edit you package.php.yml like this:
 devDeps:
   dn-bundle-plugin: '*'
 ...
-plugins:
-  - DevelNextBundle
+
 develnext-bundle:
   version: 1.0.0
   name: simple-bundle


### PR DESCRIPTION
Не обязательно прописывать plugins, если оно уже задекларировано в самом плагине, в его package.php.yml и если у него `type: plugin`. Достаточно его подключить в devDeps.